### PR TITLE
stop logging pings

### DIFF
--- a/server.py
+++ b/server.py
@@ -1,12 +1,22 @@
 import os
 import asyncio
+import logging
 import uuid
 from datetime import datetime
 
 from websockets import ConnectionClosed
 
 from sanic import Sanic
+from sanic.log import access_logger
 from sanic.response import file, redirect
+
+
+class PingFilter(logging.Filter):
+    def filter(self, record):
+        return not (record.request.endswith("?healthz") and record.status == 200)
+
+
+access_logger.addFilter(PingFilter())
 
 app = Sanic()
 app.socks = []


### PR DESCRIPTION
This commit will stop sanic from logging ping requests (ending in
?healthz). There's little value in us logging them when k8s will handle
the failure to handle a ping anyway.

Currently the logs being full of pings stops us determining if this
service is used, and worth maintaining.